### PR TITLE
Update permalinks to rock paper scissors project

### DIFF
--- a/_posts/2000-01-10-front-end-project-part-1.markdown
+++ b/_posts/2000-01-10-front-end-project-part-1.markdown
@@ -2,7 +2,7 @@
 title: Rock Paper Scissors Project, Part 1
 layout: post
 date: 2000-01-10
-permalink: vending-machine-project-part-1
+permalink: rock-paper-scissors-project-part-1
 program: front-end
 tags: front-end
 lessontype: fe-new

--- a/_posts/2000-01-11-front-end-project-part-2.markdown
+++ b/_posts/2000-01-11-front-end-project-part-2.markdown
@@ -2,7 +2,7 @@
 title: Rock Paper Scissors Project, Part 2
 layout: post
 date: 2000-01-11
-permalink: vending-machine-project-part-2
+permalink: rock-paper-scissors-project-part-2
 program: front-end
 tags: front-end
 lessontype: fe-new

--- a/_posts/2000-01-12-front-end-project-part-3-extensions.markdown
+++ b/_posts/2000-01-12-front-end-project-part-3-extensions.markdown
@@ -2,7 +2,7 @@
 title: Rock Paper Scissors Project Extensions
 layout: post
 date: 2000-01-12
-permalink: vending-machine-project-part-3
+permalink: rock-paper-scissors-project-part-3
 program: front-end
 tags: front-end
 lessontype: fe-new


### PR DESCRIPTION
Changed the front-end project permalinks so that the URLs would match the project name.

Before: `http://try.turing.io/vending-machine-project-part-1`

After: `http://try.turing.io/rock-paper-scissors-project-part-1`

Tested locally with `jekyll serve`.

@rwarbelow 