### PR TITLE
Feature/online open close sections

### DIFF
--- a/backend-online/index.md
+++ b/backend-online/index.md
@@ -4,6 +4,8 @@ layout: lesson
 
 # Back-End Online Curriculum
 
+<!-- - [Welcome](./welcome-bee-single) -->
+- [Welcome](./welcome-bee-weekend)
 - [How the Web Works](./how-the-web-works)
 - [What is Back-End Engineering?](./what-is-bee)
 - [Ruby Review](./ruby-review)
@@ -12,3 +14,4 @@ layout: lesson
 - [Control Flow](./control-flow)
 - [Twitter Project](./twitter)
 - [Loops](./code-challenge)
+- [Wrap Up](./wrap-up)

--- a/backend-online/welcome-bee-single/index.md
+++ b/backend-online/welcome-bee-single/index.md
@@ -1,0 +1,22 @@
+---
+layout: lesson
+---
+
+# Welcome to Try Coding!
+
+### To Get Set Up:
+
+- Open up <a target="blank" href="https://repl.it/~">repl.it</a> in a browser (preferably Chrome) and login to your account
+- In another tab, open up <a target="blank" href="https://try.turing.io/">try.turing.io</a>
+- Make sure you have a fully charged computer or a charger close by
+- We recommend using headphones and finding a quiet work space to limit distractions.
+
+### What to Expect
+
+Over the course of the day, we will write code, explore the mindsets that successful developers have, and learn a little more about Turing.  We will ask you to introduce yourself, ask questions, and occasionally share out answers to the technical work we do! Below is our agenda for the day:
+
+- **10:00 - 11:45** Welcome, Intros, and Instruction (1 break)
+- **11:45 - 12:00** Break
+- **12:00 - 12:30** Student/Alum Panel, Turing Info
+- **12:30 - 2:15**  Instruction (2 breaks)
+- **2:15  - 2:30**  Wrap Up

--- a/backend-online/welcome-bee-weekend/index.md
+++ b/backend-online/welcome-bee-weekend/index.md
@@ -1,0 +1,23 @@
+---
+layout: lesson
+---
+
+# Welcome to Try Coding!
+
+### To Get Set Up:
+
+- Open up <a target="blank" href="https://repl.it/~">repl.it</a> in a browser (preferably Chrome) and login to your account
+- In another tab, open up <a target="blank" href="https://try.turing.io/">try.turing.io</a>
+- Make sure you have a fully charged computer or a charger close by
+- We recommend using headphones and finding a quiet work space to limit distractions.
+
+### What to Expect
+
+Over the course of the day, we will write code, explore the mindsets that successful developers have, and learn a little more about Turing.  We will ask you to introduce yourself, ask questions, and occasionally share out answers to the technical work we do! Below is our agenda for the day:
+
+- **10:00 - 11:45** Welcome, Intros, and Instruction (1 break)
+- **11:45 - 12:00** Break
+- **12:00 - 12:45** Student & Alum Panel
+- **12:45 - 1:00**  Break
+- **12:30 - 2:15**  Instruction (2 breaks)
+- **2:15  - 2:30**  Wrap Up

--- a/backend-online/wrap-up/index.md
+++ b/backend-online/wrap-up/index.md
@@ -3,3 +3,23 @@ layout: lesson
 ---
 
 # Wrap Up
+
+## Reflection
+
+As we wrap up our day together, take a moment to reflect on the questions below.
+
+<div class="try-it-new">
+  <h2>Wrap Up: Reflection</h2>
+  <ul>
+    <li>What was FUN about coding today?</li>
+    <li>When did you demonstrate a growth mindset?</li>
+    <li>What lingering questions do you have about the technical work we did today?</li>
+  </ul>
+</div>
+
+## Contact
+
+- For technical questions regarding the content we learned today, you can email Amy at amy@turing.io
+- For questions regarding applying, enrolling, or financing, please email Erin at erin@turing.io
+
+## Additional Resources

--- a/backend-online/wrap-up/index.md
+++ b/backend-online/wrap-up/index.md
@@ -1,0 +1,5 @@
+---
+layout: lesson
+---
+
+# Wrap Up

--- a/frontend-online/index.md
+++ b/frontend-online/index.md
@@ -4,6 +4,8 @@ layout: lesson
 
 # Front-End Online Curriculum
 
+- [Welcome](./welcome-fee-single)
+<!-- - [Welcome](./welcome-fee-weekend) -->
 - [What is Front-End Engineering?](./what-is-fee)
 - [HTML Review](./html-review)
 - [Programming is Hard](./programming)
@@ -11,3 +13,4 @@ layout: lesson
 - [Interacting with HTML](./interacting-with-html)
 - [Event Listeners](./event-listeners)
 - [Dynamically Adding HTML](./dynamically-adding-html)
+- [Wrap Up](./wrap-up)

--- a/frontend-online/welcome-fee-single/index.md
+++ b/frontend-online/welcome-fee-single/index.md
@@ -1,0 +1,23 @@
+---
+layout: lesson
+---
+
+# Welcome to Try Coding!
+
+### To Get Set Up:
+
+- Open up <a target="blank" href="http://codepen.io/">codepen.io</a> in a browser (preferably Chrome) and login to your account
+- In another tab, open up <a target="blank" href="https://try.turing.io/">try.turing.io</a>
+- Make sure you have a fully charged computer or a charger close by
+- We recommend using headphones and finding a quiet work space to limit distractions.
+
+### What to Expect
+
+Over the course of the day, we will write code, explore the mindsets that successful developers have, and learn a little more about Turing.  We will ask you to introduce yourself, ask questions, and occasionally share out answers to the technical work we do! Below is our agenda for the day:
+
+- **10:00 - 11:45** Welcome, Intros, and Instruction (1 break)
+- **11:45 - 12:00** Break
+- **12:00 - 12:45** Turing Info: Enrollment, Admissions, & Financing
+- **12:45 - 1:00**  Break
+- **12:30 - 2:15**  Instruction (2 breaks)
+- **2:15  - 2:30**  Wrap Up

--- a/frontend-online/welcome-fee-weekend/index.md
+++ b/frontend-online/welcome-fee-weekend/index.md
@@ -1,0 +1,22 @@
+---
+layout: lesson
+---
+
+# Welcome to Try Coding!
+
+### To Get Set Up:
+
+- Open up <a target="blank" href="http://codepen.io/">codepen.io</a> in a browser (preferably Chrome) and login to your account
+- In another tab, open up <a target="blank" href="https://try.turing.io/">try.turing.io</a>
+- Make sure you have a fully charged computer or a charger close by
+- We recommend using headphones and finding a quiet work space to limit distractions.
+
+### What to Expect
+
+Over the course of the day, we will write code, explore the mindsets that successful developers have, and learn a little more about Turing.  We will ask you to introduce yourself, ask questions, and occasionally share out answers to the technical work we do! Below is our agenda for the day:
+
+- **10:00 - 11:45** Welcome, Intros, and Instruction (1 break)
+- **11:45 - 12:00** Break
+- **12:00 - 12:30** Student/Alum Panel, Turing Info
+- **12:30 - 2:15**  Instruction (2 breaks)
+- **2:15  - 2:30**  Wrap Up

--- a/frontend-online/wrap-up/index.md
+++ b/frontend-online/wrap-up/index.md
@@ -17,6 +17,9 @@ As we wrap up our day together, take a moment to reflect on the questions below.
   </ul>
 </div>
 
-## Additional Resources
-
 ## Contact
+
+- For technical questions regarding the content we learned today, you can email Amy at amy@turing.io
+- For questions regarding applying, enrolling, or financing, please email Erin at erin@turing.io
+
+## Additional Resources

--- a/frontend-online/wrap-up/index.md
+++ b/frontend-online/wrap-up/index.md
@@ -1,0 +1,22 @@
+---
+layout: lesson
+---
+
+# Wrap Up
+
+## Reflection
+
+As we wrap up our day together, take a moment to reflect on the questions below.
+
+<div class="try-it-new">
+  <h2>Wrap Up: Reflection</h2>
+  <ul>
+    <li>What was FUN about coding today?</li>
+    <li>When did you demonstrate a growth mindset?</li>
+    <li>What lingering questions do you have about the technical work we did today?</li>
+  </ul>
+</div>
+
+## Additional Resources
+
+## Contact


### PR DESCRIPTION
This PR:
- Adds a "Wrap Up" section with a reflection and contact info
- Adds two "Welcome" sections for each end - one for single day and one for a weekend event. Each Welcome page includes set up info, agenda, and what to expect info.

Downfall:
- TC Instructor will need to comment/un-comment to make sure the correct "Welcome" link appears before teaching each workshop.